### PR TITLE
Fix keying issues when trait1 == trait2 but dataset1 != dataset2

### DIFF
--- a/R/coloc.R
+++ b/R/coloc.R
@@ -24,8 +24,8 @@ block=as.numeric(args[5])
 
 # dataset id string
 dataset_id_string=strsplit(args[6],"-----")
-dataset_id_1 =dataset_id_string[[1]][1]
-dataset_id_2 =dataset_id_string[[1]][2]
+dataset_id_1 =strsplit(dataset_id_string[[1]][1],"--")[[1]][1]
+dataset_id_2 =strsplit(dataset_id_string[[1]][2],"--")[[1]][1]
 
 debug = FALSE
 if(length(args) >= 7){
@@ -36,7 +36,7 @@ dt.list = fread(colocList, head=F)
 dt.map1 = fread(map1, head=F)
 dt.map2 = fread(map2, head=F)
 
-setnames(dt.list, c("URL1", "trait1", "region1", "URL2", "trait2", "region2"))
+setnames(dt.list, c("URL1", "trait1", "region1", "dataset1", "URL2", "trait2", "region2", "dataset2"))
 
 nList = nrow(dt.list)
 message(nList, " in list")
@@ -65,8 +65,8 @@ message("Processing from ", start, " to ", end)
 dt.list = dt.list[start:end]
 nList = nrow(dt.list)
 
-dt.list[, out1:=paste0(trait1, "---", gsub(":", ".", region1), ".txt")]
-dt.list[, out2:=paste0(trait2, "---", gsub(":", ".", region2), ".txt")]
+dt.list[, out1:=paste0(dataset1, "---", trait1, "---", gsub(":", ".", region1), ".txt")]
+dt.list[, out2:=paste0(dataset2, "---", trait2, "---", gsub(":", ".", region2), ".txt")]
 
 ##################
 # extract geno
@@ -289,6 +289,8 @@ lbf2 = dt.map2[V1=="lbf_variable_prefix"]$V2
 for(f1 in dt3.cur1$out1){
     # prepare the first one
     dt.list.cur = dt.list[out1==f1]
+    dataset1.cur = dt.list.cur$dataset1[1]
+    trait1.cur = dt.list.cur$trait1[1]
     region1.cur = dt.list.cur$region1[1]
 
     dt1 = fread(paste0(f1))
@@ -300,7 +302,7 @@ for(f1 in dt3.cur1$out1){
     dt.map1.use[!V1 %in% c("rsid"), V1:=paste0(V1, "1")]
     setnames(dt1, dt.map1.use$V2, dt.map1.use$V1)
     dt1[, rsid:=gsub("chr23", "chrX", rsid)]
-    dt1 = dt1[region1 == region1.cur]
+    dt1 = dt1[region1 == region1.cur & trait1 == trait1.cur]
 
     use_cols1 = c(dt.map1.use$V1, lbfn_cols1)
     dt1.use = dt1[, ..use_cols1]
@@ -314,6 +316,8 @@ for(f1 in dt3.cur1$out1){
 
     for(idx.f2 in 1:nrow(dt.list.cur)){
         f2 = dt.list.cur$out2[idx.f2]
+        dataset2.cur = dt.list.cur$dataset2[idx.f2]
+        trait2.cur = dt.list.cur$trait2[idx.f2]
         region2.cur = dt.list.cur$region2[idx.f2]
         nProcess = nProcess + 1
         message("======", nProcess, "/", nList, ": ", f1, ", ", f2)
@@ -328,7 +332,7 @@ for(f1 in dt3.cur1$out1){
         dt.map2.use[!V1 %in% c("rsid"), V1:=paste0(V1, "2")]
         setnames(dt2, dt.map2.use$V2, dt.map2.use$V1)
         dt2[, rsid:=gsub("chr23", "chrX", rsid)]
-        dt2 = dt2[region2==region2.cur]
+        dt2 = dt2[region2==region2.cur & trait2==trait2.cur]
 
         use_cols2 = c(dt.map2.use$V1, lbfn_cols2)
         dt2.use = dt2[, ..use_cols2]
@@ -389,10 +393,12 @@ for(f1 in dt3.cur1$out1){
                 dt.sum[, idx2:=cs2[idx2]]
 
                 dt.sum1 = merge(merge(dt.sum, dt3.1, by.x="idx1", by.y="cs1"), dt3.2, by.x="idx2", by.y="cs2")
-                dt.sum1$trait1 = dt3[1]$trait1
-                dt.sum1$trait2 = dt3[1]$trait2
-                dt.sum1$region1 = dt3[1]$region1
-                dt.sum1$region2 = dt3[1]$region2
+                dt.sum1$dataset1 = dataset1.cur
+                dt.sum1$dataset2 = dataset2.cur
+                dt.sum1$trait1 = trait1.cur
+                dt.sum1$trait2 = trait2.cur
+                dt.sum1$region1 = region1.cur
+                dt.sum1$region2 = region2.cur
                 dt.sum1$nsnps1 = nrow(dt1)
                 dt.sum1$nsnps2 = nrow(dt2)
                 setnames(dt.sum1, c("idx1", "idx2"), c("cs1", "cs2"))
@@ -554,7 +560,7 @@ for(f1 in dt3.cur1$out1){
 dt.coloc = rbindlist(dts)
 dt.hits = rbindlist(dts.hits, fill=TRUE)
 if(nrow(dt.coloc) != 0){
-    setcolorder(dt.coloc, c("trait1", "trait2", "region1", "region2", "cs1", "cs2"))
+    setcolorder(dt.coloc, c("dataset1", "dataset2", "trait1", "trait2", "region1", "region2", "cs1", "cs2"))
 }
 fwrite(dt.coloc, file=output, sep="\t", na="NA", quote=F)
 fwrite(dt.hits, file=output.hits, sep="\t", na="NA",quote=F)

--- a/R/colocPairStr.R
+++ b/R/colocPairStr.R
@@ -56,7 +56,7 @@ processInfo <- function(infostr, side){
         stop("the information is invalid: ", infostr)
     }
 
-    system(paste0("gsutil cat ", region_list, " > regions.tsv"))    
+    system(paste0("gsutil cat ", region_list, " > regions.tsv"))
     downFile(region_list, "regions.tsv")
     downFile(mapping, paste0("map", side, ".txt"))
 
@@ -85,8 +85,9 @@ processInfo <- function(infostr, side){
 
     dt.region[!grepl("chr", CHR), CHR:=paste0("chr", CHR)]
     dt.region[, CHR:=gsub("chr23", "chrX", CHR)]
+    dt.region[, dataset:=infos_val[1]]
     if(side != 1){
-        sel_col = c("start", "end")
+        sel_col = c("start", "end", "dataset")
         setnames(dt.region, sel_col, paste0(sel_col, side))
     }
 
@@ -104,7 +105,7 @@ for(info1 in lines_1){
     infos1 = processInfo(info1, 1)
     dt1 = unique(infos1[["region"]])
     for(info2 in lines_2){
-        
+
         infos2 = processInfo(info2, 2)
         dt2 = unique(infos2[["region"]])
 
@@ -116,21 +117,22 @@ for(info1 in lines_1){
         tar_name = paste0(infos1[["name"]], "-----", infos2[["name"]], ".pairs.tar.gz")
         n_name = paste0(infos1[["name"]], "-----", infos2[["name"]], ".N.count")
 
-        dt3 = dt1[dt2, .(URL, trait, region, i.URL, i.trait, i.region), on=.(CHR, start <= end2, end >= start2), nomatch=0]
+        dt3 = dt1[dt2, .(URL, trait, region, dataset, i.URL, i.trait, i.region, i.dataset2), on=.(CHR, start <= end2, end >= start2), nomatch=0]
 
 
         setnames(dt3, c("URL", "i.URL"), c("URL1", "URL2"))
         setnames(dt3, c("trait", "i.trait"), c("trait1", "trait2"))
         setnames(dt3, c("region", "i.region"), c("region1", "region2"))
+        setnames(dt3, c("dataset", "i.dataset2"), c("dataset1", "dataset2"))
 
-        dt3.ord = dt3[order(trait1, region1, trait2, region2)]
+        dt3.ord = dt3[order(dataset1, trait1, region1, dataset2, trait2, region2)]
         message(nrow(dt3.ord), " total pairs have overlapped region.")
         if(bExclude){
-            dt3.ord = dt3.ord[trait1 != trait2]
-            message(nrow(dt3.ord), " pairs after removing traits with the same name")
+            dt3.ord = dt3.ord[dataset1 != dataset2 | trait1 != trait2]
+            message(nrow(dt3.ord), " pairs after removing traits with the same name in the same dataset")
         }
         fwrite(dt3.ord, file=out, sep="\t", col.names=F, na=NA)
-        
+
         cat(nrow(dt3.ord), file=n_name, sep="\n")
         #tar and gzip options to remove all non-reproducible values
         system(paste0("tar --format=gnu  --sort=name --numeric-owner --owner=0 --group=0 --mode='go-rwx,u-rw' --mtime='1970-01-01' --no-recursion --null -cf -  pairs.tsv map1.txt map2.txt coloc.info|gzip --no-name --best > ",tar_name))

--- a/R/colocPairStr.R
+++ b/R/colocPairStr.R
@@ -56,7 +56,7 @@ processInfo <- function(infostr, side){
         stop("the information is invalid: ", infostr)
     }
 
-    system(paste0("gsutil cat ", region_list, " > regions.tsv"))
+    system2("gsutil", c("cat", region_list), stdout = "regions.tsv")
     downFile(region_list, "regions.tsv")
     downFile(mapping, paste0("map", side, ".txt"))
 

--- a/R/mergeAllPair.R
+++ b/R/mergeAllPair.R
@@ -28,13 +28,18 @@ for(file1 in files.val){
     idx = idx + 1
     message(idx, "/", n, ": ", file1)
     dt = fread(file1)
-    name1 = basename(file1) 
+    name1 = basename(file1)
     name2 = gsub(".sum.tsv.gz", "", name1)
     name_sep = stri_split_fixed(name2, "-----", simplify=TRUE)
 
     dt[, colocRes:=name1]
-    dt[, dataset1:=name_sep[1]]
-    dt[, dataset2:=name_sep[2]]
+    # dataset1 and dataset2 columns should already exist in the file from coloc.R
+    if(!"dataset1" %in% colnames(dt)){
+        stop("dataset1 column not found in file: ", file1)
+    }
+    if(!"dataset2" %in% colnames(dt)){
+        stop("dataset2 column not found in file: ", file1)
+    }
     nTotal = nTotal + nrow(dt)
     message(" Current: ", nrow(dt), " rows, total: ", nTotal)
 

--- a/R/mergeAllPair.R
+++ b/R/mergeAllPair.R
@@ -29,8 +29,6 @@ for(file1 in files.val){
     message(idx, "/", n, ": ", file1)
     dt = fread(file1)
     name1 = basename(file1)
-    name2 = gsub(".sum.tsv.gz", "", name1)
-    name_sep = stri_split_fixed(name2, "-----", simplify=TRUE)
 
     dt[, colocRes:=name1]
     # dataset1 and dataset2 columns should already exist in the file from coloc.R

--- a/python/filter_h4.py
+++ b/python/filter_h4.py
@@ -61,8 +61,8 @@ output_fname = sys.argv[4]
 ## load colocalization identifiers to memory
 
 ds_ids = dataset_ids.split("-----")
-dataset1 = ds_ids[0]
-dataset2 = ds_ids[1]
+dataset1 = ds_ids[0].split("--")[0]
+dataset2 = ds_ids[1].split("--")[0]
 
 data_set = set()
 

--- a/python/mergeVariants.py
+++ b/python/mergeVariants.py
@@ -34,8 +34,8 @@ coloc_fname = sys.argv[1]
 flist = sys.argv[2]
 dataset_ids = sys.argv[3]
 ds_ids = dataset_ids.split("-----")
-dataset1 = ds_ids[0]
-dataset2 = ds_ids[1]
+dataset1 = ds_ids[0].split("--")[0]
+dataset2 = ds_ids[1].split("--")[0]
 
 
 output_fname = sys.argv[4]

--- a/wdl/template.json
+++ b/wdl/template.json
@@ -4,7 +4,7 @@
 
     "ColocSusieDirectMulti.colocInfo2": "gs://finngen-production-library-green/sandbox_coloc_resources/coloc_susie/resources.txt",
     "ColocSusieDirectMulti.nColocPerBatch": 1500,
-    "ColocSusieDirectMulti.docker": "europe-west1-docker.pkg.dev/finngen-refinery-dev/fg-refinery-registry/coloc.susie.direct:0bdafd4-mk",
+    "ColocSusieDirectMulti.docker": "europe-west1-docker.pkg.dev/finngen-refinery-dev/fg-refinery-registry/coloc.susie.direct:80d0f28-mk",
     "ColocSusieDirectMulti.excludeSameNameTrait": true,
     "ColocSusieDirectMulti.h4pp_thresh": 0.5,
     "ColocSusieDirectMulti.cs_log10bf_thresh": 0.9,

--- a/wdl/template.json
+++ b/wdl/template.json
@@ -4,7 +4,7 @@
 
     "ColocSusieDirectMulti.colocInfo2": "gs://finngen-production-library-green/sandbox_coloc_resources/coloc_susie/resources.txt",
     "ColocSusieDirectMulti.nColocPerBatch": 1500,
-    "ColocSusieDirectMulti.docker": "europe-west1-docker.pkg.dev/finngen-refinery-dev/fg-refinery-registry/coloc.susie.direct:1bfc87d",
+    "ColocSusieDirectMulti.docker": "europe-west1-docker.pkg.dev/finngen-refinery-dev/fg-refinery-registry/coloc.susie.direct:0bdafd4-mk",
     "ColocSusieDirectMulti.excludeSameNameTrait": true,
     "ColocSusieDirectMulti.h4pp_thresh": 0.5,
     "ColocSusieDirectMulti.cs_log10bf_thresh": 0.9,


### PR DESCRIPTION
This PR fixes issues when `trait1 == trait2` but `dataset1 != dataset2`, which occurs when you testing GWAS-molQTL colocalization across different cell types